### PR TITLE
Set task dependencies in build/test action

### DIFF
--- a/.github/actions/build-test/main.js
+++ b/.github/actions/build-test/main.js
@@ -33,7 +33,8 @@ function platformTasks(platform) {
       runtime: "node",
       revision,
     },
-    platform
+    platform,
+    [buildTask]
   );
 
   return [buildTask, testTask];


### PR DESCRIPTION
Make sure the build task finishes before the test action starts in node build/test requests.