### PR TITLE
Run tests while recording using a timeout

### DIFF
--- a/replay-test/client.ts
+++ b/replay-test/client.ts
@@ -29,7 +29,7 @@ export default class ProtocolClient {
   nextMessageId = 1;
 
   constructor(address: string, callbacks: ClientCallbacks) {
-    this.socket = new WebSocket(address);
+    this.socket = new (WebSocket.default || WebSocket)(address);
     this.callbacks = callbacks;
 
     this.socket.on("open", this.openWaiter.resolve);


### PR DESCRIPTION
If a test hangs while recording then the entire test harness will hang.  This PR uses spawn with a timeout instead of spawnSync to avoid this.  I also ran into a problem where creating WebSockets works in different ways depending on the node version apparently.  This tries to deal with both cases, I'm sure there's a better way to do this though.