### PR TITLE
Kill lingering subprocesses when test runner finishes

### DIFF
--- a/replay-test/run.ts
+++ b/replay-test/run.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import { spawn } from "child_process";
 import { TestManifest, NodeTestIgnoreList } from "./manifest";
 import { listAllRecordings, uploadRecording } from "@recordreplay/recordings-cli";
-import { defer, Deferred } from "./utils";
+import { defer, Deferred, killTransitiveSubprocesses } from "./utils";
 import ProtocolClient from "./client";
 
 const Usage = `
@@ -21,9 +21,14 @@ Options:
   --server <address>: Set server to connect to (default wss://dispatch.replay.io).
 `;
 
-function bailout(message) {
+function doExit(code: number) {
+  // Kill any lingering subprocesses before exiting.
+  killTransitiveSubprocesses();
+}
+
+function bailout(message: string) {
   console.log(message);
-  process.exit(1);
+  doExit(1);
 }
 
 if (process.argv.length == 2) {
@@ -99,11 +104,11 @@ async function main() {
 
   if (gNumFailures) {
     console.error(`Had ${gNumFailures} test failures`);
-    process.exit(1);
+    doExit(1);
   }
 
   console.log("All tests passed, exiting");
-  process.exit(0);
+  doExit(0);
 }
 
 main();

--- a/replay-test/utils.ts
+++ b/replay-test/utils.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "child_process";
+
 export function assert(v: any, why = ""): asserts v {
   if (!v) {
     const error = new Error(`Assertion Failed: ${why}`);
@@ -23,4 +25,40 @@ export function defer<T>() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+// Kill all running subprocesses of the current process.
+export function killTransitiveSubprocesses() {
+  assert(process.platform != "win32", "NYI");
+
+  const childToParent: Map<number, number> = new Map();
+
+  const lines = spawnSync("ps", ["-A", "-o", "ppid,pid"]).stdout.toString().split("\n");
+  for (const line of lines) {
+    const match = /(\d+)\s+(\d+)/.exec(line);
+    if (match && +match[1] > 1) {
+      childToParent.set(+match[2], +match[1]);
+    }
+  }
+
+  for (const childPid of childToParent.keys()) {
+    if (shouldKillSubprocess(childPid)) {
+      try {
+        spawnSync("kill", ["-KILL", childPid.toString()]);
+      } catch (e) {}
+    }
+  }
+
+  function shouldKillSubprocess(childPid: number) {
+    while (true) {
+      const parent = childToParent.get(childPid);
+      if (!parent) {
+        return false;
+      }
+      if (parent == process.pid) {
+        return true;
+      }
+      childPid = parent;
+    }
+  }
 }


### PR DESCRIPTION
If there are any subprocesses remaining from tests which timed out or created child processes that haven't exited, the test runner gets stuck.