### PR TITLE
Add assert that input data to uv__fs_write is consistent when replaying

### DIFF
--- a/deps/uv/src/unix/fs.c
+++ b/deps/uv/src/unix/fs.c
@@ -1116,6 +1116,11 @@ static ssize_t uv__fs_write(uv_fs_t* req) {
     abort();
 #endif
 
+  // https://github.com/RecordReplay/backend/issues/4792
+  V8RecordReplayAssert("uv__fs_write start %d %d %d %d",
+                       req->file, (int)req->off, (int)req->nbufs,
+                       req->nbufs ? (int)req->bufs[0].len : -1);
+
   if (req->off < 0) {
     if (req->nbufs == 1)
       r = write(req->file, req->bufs[0].base, req->bufs[0].len);


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/4792