### PR TITLE
Disable wasm async compilation when recording/replaying

### DIFF
--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11677,6 +11677,7 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   // complicated and getting this it to behave consistently when replaying in
   // the presence of multiple threads isn't worth the hassle.
   internal::FLAG_wasm_num_compilation_tasks = 1;
+  internal::FLAG_wasm_async_compilation = false;
 }
 
 bool IsMainThread() {


### PR DESCRIPTION
Tentative fix for https://github.com/RecordReplay/backend/issues/4886.  We don't want wasm compilation to run on multiple threads, but there are still cases when background compile jobs are being used.  I found another flag used to control this behavior which should be more effective at disabling async compilation.