### PR TITLE
Ignore exception unwinds when diverged from recording

### DIFF
--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11199,6 +11199,11 @@ extern "C" void V8RecordReplayGetCurrentException(MaybeLocal<Value>* exception) 
 void RecordReplayOnExceptionUnwind(Isolate* isolate) {
   CHECK(gRecordingOrReplaying);
   CHECK(IsMainThread());
+
+  if (recordreplay::HasDivergedFromRecording()) {
+    return;
+  }
+
   CHECK(!gCurrentException);
 
   HandleScope scope(isolate);


### PR DESCRIPTION
If an exception is thrown while generating the pause data at an exception site in node, we bust on an assert that there isn't already a current exception.  This prevents pauses from being created and analyses from running at affected points.  This PR fixes this by not reporting exceptions to the recorder after diverging from the recording so that we don't hit this assertion.