### PR TITLE
Add missing exit call

### DIFF
--- a/replay-test/run.ts
+++ b/replay-test/run.ts
@@ -24,6 +24,7 @@ Options:
 function doExit(code: number) {
   // Kill any lingering subprocesses before exiting.
   killTransitiveSubprocesses();
+  process.exit(code);
 }
 
 function bailout(message: string) {


### PR DESCRIPTION
This is causing all our test runs to be marked as passed, whether there were test failures or not.