### PR TITLE
Ignore certain frames when capturing stacks

### DIFF
--- a/deps/v8/src/objects/stack-frame-info.cc
+++ b/deps/v8/src/objects/stack-frame-info.cc
@@ -204,8 +204,10 @@ void StackTraceFrame::InitializeFrameInfo(Handle<StackTraceFrame> frame) {
 
   // After initializing, we no longer need to keep a reference
   // to the frame_array.
-  frame->set_frame_array(ReadOnlyRoots(isolate).undefined_value());
-  frame->set_frame_index(-1);
+  // Disabled because RecordReplayIgnoreStackFrame() can initialize the
+  // frame info while the frame array/index are still live.
+  //frame->set_frame_array(ReadOnlyRoots(isolate).undefined_value());
+  //frame->set_frame_index(-1);
 }
 
 Handle<FrameArray> GetFrameArrayFromStackTrace(Isolate* isolate,


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5131.  I don't think this will be a permanent solution, as it doesn't completely fix the problem and it also elides information for users (seeing stack frames for node internals can be helpful), but it avoids most of the problems we're seeing due to non-deterministic stack traces.