### PR TITLE
Disable async stack traces when recording/replaying

### DIFF
--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11747,6 +11747,10 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   // the presence of multiple threads isn't worth the hassle.
   internal::FLAG_wasm_num_compilation_tasks = 1;
   internal::FLAG_wasm_async_compilation = false;
+
+  // Async stack traces can vary when recording vs. replaying, apparently depending
+  // on how the code has been compiled.
+  internal::FLAG_async_stack_traces = false;
 }
 
 bool IsMainThread() {


### PR DESCRIPTION
Tentative fix for https://github.com/RecordReplay/backend/issues/5330.  Capturing a stack trace in V8 will capture both on stack frames and an async stack trace.  The async stack trace seems like it can vary non-deterministically though the underlying reason is unknown.  This PR disables capturing async stack traces to see if it fixes the non-deterministic behavior.