### PR TITLE
Add RECORD_REPLAY_DONT_RECORD env var

### DIFF
--- a/build.js
+++ b/build.js
@@ -63,7 +63,7 @@ if (process.platform == "linux") {
     env: {
       ...process.env,
       // Disable recording when node runs as part of its compilation process.
-      RECORD_REPLAY_DRIVER: "0",
+      RECORD_REPLAY_DONT_RECORD: "1",
     },
   });
 }

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11420,6 +11420,9 @@ extern "C" void V8RecordReplayBytes(const char* why, void* buf, size_t size) {
 }
 
 bool recordreplay::AreEventsDisallowed() {
+  if (IsRecordingOrReplaying()) {
+    return false;
+  }
   return gRecordReplayAreEventsDisallowed();
 }
 

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11421,9 +11421,9 @@ extern "C" void V8RecordReplayBytes(const char* why, void* buf, size_t size) {
 
 bool recordreplay::AreEventsDisallowed() {
   if (IsRecordingOrReplaying()) {
-    return false;
+    return gRecordReplayAreEventsDisallowed();
   }
-  return gRecordReplayAreEventsDisallowed();
+  return false;
 }
 
 void recordreplay::BeginPassThroughEvents() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1100,6 +1100,10 @@ static void* OpenDriverHandle() {
 }
 
 static void InitializeRecordReplay(int* pargc, char*** pargv) {
+  if (getenv("RECORD_REPLAY_DONT_RECORD")) {
+    return;
+  }
+
   const char* dispatchAddress = getenv("RECORD_REPLAY_SERVER");
   if (!dispatchAddress) {
     // 4/21/2021: For backwards compatibility we also check an older env


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5329.  We have a way to disable recording by setting the RECORD_REPLAY_DRIVER env var to an invalid value, but it would be clearer if we used a dedicated environment variable for this.  This PR also fixes a crash we were hitting when not recording.