### PR TITLE
Run jest tests during build/test tasks

### DIFF
--- a/.github/actions/build-test-branch/main.js
+++ b/.github/actions/build-test-branch/main.js
@@ -64,7 +64,18 @@ function platformTasks(platform) {
     [buildTask]
   );
 
-  return [buildTask, testTask];
+  const jestTask = newTask(
+    `Run random Jest tests ${platform}`,
+    {
+      kind: "JestTests",
+      revision: nodeRevision,
+      driverRevision,
+    },
+    platform,
+    [buildTask]
+  );
+
+  return [buildTask, testTask, jestTask];
 }
 
 function getBranchName(refName) {

--- a/.github/actions/build-test/main.js
+++ b/.github/actions/build-test/main.js
@@ -37,5 +37,15 @@ function platformTasks(platform) {
     [buildTask]
   );
 
-  return [buildTask, testTask];
+  const jestTask = newTask(
+    `Run random Jest tests ${platform}`,
+    {
+      kind: "JestTests",
+      revision,
+    },
+    platform,
+    [buildTask]
+  );
+
+  return [buildTask, testTask, jestTask];
 }


### PR DESCRIPTION
It would be nice to test our node builds more thoroughly before releasing them, using our existing tasks to run randomized jest tests.