### PR TITLE
Add pretty printing support

### DIFF
--- a/deps/v8/src/codegen/compiler.cc
+++ b/deps/v8/src/codegen/compiler.cc
@@ -2672,6 +2672,7 @@ static void SetFlagsByURL(UnoptimizedCompileFlags& flags,
     if (script_details.name_obj.ToHandle(&script_name)) {
       std::unique_ptr<char[]> name_cstr = String::cast(*script_name).ToCString();
       if (strstr(name_cstr.get(), pretty_print_pattern)) {
+        OnStartPrettyPrint();
         flags.set_pretty_print(true);
       }
     }

--- a/deps/v8/src/codegen/compiler.cc
+++ b/deps/v8/src/codegen/compiler.cc
@@ -2666,14 +2666,13 @@ static void SetFlagsByURL(UnoptimizedCompileFlags& flags,
     }
   }
 
-  static const char* dump_ast_pattern = getenv("DUMP_AST");
-  if (dump_ast_pattern) {
+  static const char* pretty_print_pattern = getenv("PRETTY_PRINT");
+  if (pretty_print_pattern) {
     Handle<Object> script_name;
     if (script_details.name_obj.ToHandle(&script_name)) {
       std::unique_ptr<char[]> name_cstr = String::cast(*script_name).ToCString();
-      if (strstr(name_cstr.get(), dump_ast_pattern)) {
-        fprintf(stderr, "Dumping AST %s\n", name_cstr.get());
-        flags.set_dump_ast(true);
+      if (strstr(name_cstr.get(), pretty_print_pattern)) {
+        flags.set_pretty_print(true);
       }
     }
   }
@@ -2700,8 +2699,8 @@ MaybeHandle<SharedFunctionInfo> CompileScriptOnMainThread(
     Compiler::CompileToplevel(&parse_info, script, isolate,
                               is_compiled_scope);
 
-  if (flags.dump_ast()) {
-    DumpASTEvents("ast.bin");
+  if (flags.pretty_print()) {
+    PrettyPrintScript(isolate, script);
   }
 
   return rv;
@@ -3023,8 +3022,8 @@ MaybeHandle<JSFunction> Compiler::GetWrappedFunction(
     if (maybe_result.is_null()) isolate->ReportPendingMessages();
     ASSIGN_RETURN_ON_EXCEPTION(isolate, top_level, maybe_result, JSFunction);
 
-    if (flags.dump_ast()) {
-      DumpASTEvents("ast.bin");
+    if (flags.pretty_print()) {
+      PrettyPrintScript(isolate, script);
     }
 
     SharedFunctionInfo::ScriptIterator infos(isolate, *script);

--- a/deps/v8/src/parsing/parse-info.h
+++ b/deps/v8/src/parsing/parse-info.h
@@ -46,7 +46,8 @@ class Zone;
   V(is_eager, bool, 1, _)                                \
   V(is_eval, bool, 1, _)                                 \
   V(record_replay_ignore, bool, 1, _)                    \
-  V(dump_ast, bool, 1, _)                                \
+  V(pretty_print, bool, 1, _)                            \
+  V(find_functions, bool, 1, _)                          \
   V(outer_language_mode, LanguageMode, 1, _)             \
   V(parse_restriction, ParseRestriction, 1, _)           \
   V(is_module, bool, 1, _)                               \

--- a/deps/v8/src/parsing/parse-info.h
+++ b/deps/v8/src/parsing/parse-info.h
@@ -46,6 +46,7 @@ class Zone;
   V(is_eager, bool, 1, _)                                \
   V(is_eval, bool, 1, _)                                 \
   V(record_replay_ignore, bool, 1, _)                    \
+  V(dump_ast, bool, 1, _)                                \
   V(outer_language_mode, LanguageMode, 1, _)             \
   V(parse_restriction, ParseRestriction, 1, _)           \
   V(is_module, bool, 1, _)                               \

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -59,7 +59,7 @@ enum class PrettyPrintEvent {
   // Ensure there is whitespace before the given position.
   Whitespace,
 
-  // Position of the start a subexpression.
+  // Position of the start of a subexpression.
   ExpressionStart,
 
   // End the most recent subexpression, does not have a position.
@@ -93,6 +93,9 @@ inline void AddPrettyPrintEvent(PrettyPrintEvent event, int pos) {
 
   gPrettyPrintEvents.emplace_back(event, pos);
 }
+
+// For reporting timing info.
+void OnStartPrettyPrint();
 
 void PrettyPrintScript(Isolate* isolate, Handle<Script> script);
 

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -33,6 +33,19 @@
 namespace v8 {
 namespace internal {
 
+enum class ASTEvent {
+  FunctionBodyStart, // Position of {
+  FunctionBodyEnd, // Position of }
+};
+
+extern std::vector<std::pair<ASTEvent, int>> gASTEvents;
+
+inline void AddASTEvent(ASTEvent event, int pos) {
+  gASTEvents.emplace_back(event, pos);
+}
+
+void DumpASTEvents(const char* file);
+
 enum FunctionNameValidity {
   kFunctionNameIsStrictReserved,
   kSkipFunctionNameCheck,
@@ -4243,6 +4256,10 @@ void ParserBase<Impl>::ParseFunctionBody(
     StatementListT* body, IdentifierT function_name, int pos,
     const FormalParametersT& parameters, FunctionKind kind,
     FunctionSyntaxKind function_syntax_kind, FunctionBodyType body_type) {
+  if (flags().dump_ast()) {
+    AddASTEvent(ASTEvent::FunctionBodyStart, position());
+  }
+
   if (IsResumableFunction(kind)) impl()->PrepareGeneratorVariables();
 
   DeclarationScope* function_scope = parameters.scope;
@@ -4309,6 +4326,10 @@ void ParserBase<Impl>::ParseFunctionBody(
   }
 
   scope()->set_end_position(end_position());
+
+  if (flags().dump_ast()) {
+    AddASTEvent(ASTEvent::FunctionBodyEnd, position());
+  }
 
   bool allow_duplicate_parameters = false;
 

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -1655,15 +1655,11 @@ class ParserBase {
   bool pretty_print_last_break_rbrace = false;
 
  protected:
-  inline void AddPrettyPrintBreak(int pos, bool rbrace = false) {
+  inline void AddPrettyPrintBreak(bool rbrace = false) {
     if (flags().pretty_print()) {
-      AddPrettyPrintEvent(PrettyPrintEvent::Break, pos);
+      AddPrettyPrintEvent(PrettyPrintEvent::Break, scanner()->peek_location().beg_pos);
       pretty_print_last_break_rbrace = rbrace;
     }
-  }
-
-  inline void AddPrettyPrintBreak(bool rbrace = false) {
-    AddPrettyPrintBreak(scanner()->peek_location().beg_pos, rbrace);
   }
 
   inline void AddPrettyPrintBreakIfNotRBrace() {
@@ -1672,14 +1668,10 @@ class ParserBase {
     }
   }
 
-  inline void AddPrettyPrintWhitespace(int pos) {
-    if (flags().pretty_print()) {
-      AddPrettyPrintEvent(PrettyPrintEvent::Whitespace, pos);
-    }
-  }
-
   inline void AddPrettyPrintWhitespace() {
-    AddPrettyPrintWhitespace(scanner()->peek_location().beg_pos);
+    if (flags().pretty_print()) {
+      AddPrettyPrintEvent(PrettyPrintEvent::Whitespace, scanner()->peek_location().beg_pos);
+    }
   }
 
   inline void PrettyPrintIndent() {
@@ -4452,6 +4444,7 @@ void ParserBase<Impl>::ParseFunctionBody(
                                                      kNoSourcePosition));
         expression_scope.ValidateExpression();
       }
+      AddPrettyPrintBreak(position());
       Expect(closing_token);
     }
   }
@@ -4461,8 +4454,6 @@ void ParserBase<Impl>::ParseFunctionBody(
   if (flags().find_functions()) {
     AddFunctionEvent(FunctionEvent::BodyEnd, position());
   }
-
-  AddPrettyPrintBreak(position());
 
   bool allow_duplicate_parameters = false;
 
@@ -6425,6 +6416,7 @@ typename ParserBase<Impl>::ForStatementT ParserBase<Impl>::ParseStandardForLoop(
     *cond = ParseExpression();
   }
   Expect(Token::SEMICOLON);
+  AddPrettyPrintWhitespace();
 
   if (peek() != Token::RPAREN) {
     ExpressionT exp = ParseExpression();

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -5723,6 +5723,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseIfStatement(
   }
 
   if (peek() == Token::ELSE) {
+    AddPrettyPrintWhitespace();
     AddPrettyPrintBreakIfNotRBrace();
   }
 
@@ -5913,9 +5914,11 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseDoWhileStatement(
     body = ParseStatement(nullptr, nullptr);
   }
 
+  AddPrettyPrintWhitespace();
   AddPrettyPrintBreakIfNotRBrace();
 
   Expect(Token::WHILE);
+  AddPrettyPrintWhitespace();
   Expect(Token::LPAREN);
 
   ExpressionT cond = ParseExpression();
@@ -5948,6 +5951,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseWhileStatement(
   StatementT body = impl()->NullStatement();
 
   Consume(Token::WHILE);
+  AddPrettyPrintWhitespace();
   Expect(Token::LPAREN);
   ExpressionT cond = ParseExpression();
   Expect(Token::RPAREN);

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -3514,6 +3514,17 @@ Statement* Parser::CheckCallable(Variable* var, Expression* error, int pos) {
 
 std::vector<std::pair<ASTEvent, int>> gASTEvents;
 
+static const char* ASTEventToString(ASTEvent event) {
+  switch (event) {
+    case ASTEvent::FunctionBodyStart: return "FunctionBodyStart";
+    case ASTEvent::FunctionBodyEnd: return "FunctionBodyEnd";
+    case ASTEvent::BreakIndent: return "BreakIndent";
+    case ASTEvent::Break: return "Break";
+    case ASTEvent::BreakDeindent: return "BreakDeindent";
+    default: return "Unknown";
+  }
+}
+
 void DumpASTEvents(const char* file) {
   int fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
   if (fd < 0) {
@@ -3522,9 +3533,15 @@ void DumpASTEvents(const char* file) {
     return;
   }
 
+  bool printEvents = getenv("DUMP_AST_VERBOSE");
+
   char* buf = new char[gASTEvents.size() * 5];
   int pos = 0;
   for (const auto& event : gASTEvents) {
+    if (printEvents) {
+      fprintf(stderr, "%s %d\n", ASTEventToString(event.first), event.second);
+    }
+
     buf[pos] = (char)event.first;
     uint32_t* ptr = (uint32_t*)&buf[pos + 1];
     *ptr = event.second;

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -3512,5 +3512,34 @@ Statement* Parser::CheckCallable(Variable* var, Expression* error, int pos) {
   return validate_var;
 }
 
+std::vector<std::pair<ASTEvent, int>> gASTEvents;
+
+void DumpASTEvents(const char* file) {
+  int fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+  if (fd < 0) {
+    fprintf(stderr, "open %s failed\n", file);
+    gASTEvents.clear();
+    return;
+  }
+
+  char* buf = new char[gASTEvents.size() * 5];
+  int pos = 0;
+  for (const auto& event : gASTEvents) {
+    buf[pos] = (char)event.first;
+    uint32_t* ptr = (uint32_t*)&buf[pos + 1];
+    *ptr = event.second;
+    pos += 5;
+  }
+
+  int rv = write(fd, buf, pos);
+  if (rv != pos) {
+    fprintf(stderr, "write %s failed\n", file);
+  }
+
+  close(fd);
+  delete[] buf;
+  gASTEvents.clear();
+}
+
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -3728,8 +3728,16 @@ class PrettyPrintState {
   }
 };
 
+double prettyPrintParseTime;
+
+void OnStartPrettyPrint() {
+  prettyPrintParseTime = base::Time::Now().ToJsTime();
+}
+
 void PrettyPrintScript(Isolate* isolate, Handle<Script> script) {
   DisallowGarbageCollection no_gc;
+
+  double startTime = base::Time::Now().ToJsTime();
 
   Handle<String> sourceString(String::cast(script->source()), isolate);
   String::FlatContent flatSource = sourceString->GetFlatContent(no_gc);
@@ -3787,10 +3795,14 @@ void PrettyPrintScript(Isolate* isolate, Handle<Script> script) {
     }
   }
 
+  double endTime = base::Time::Now().ToJsTime();
+
   int rv = write(STDOUT_FILENO, &prettySource[0], prettySource.size());
   CHECK(rv == (int)prettySource.size());
 
   gPrettyPrintEvents.clear();
+
+  fprintf(stderr, "Total: %.2f (%.2f pretty printing)\n", endTime - prettyPrintParseTime, endTime - startTime);
 }
 
 }  // namespace internal

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -155,6 +155,7 @@ PreParser::PreParseResult PreParser::PreParseFunction(
                            formals_end_position);
   }
 
+  AddPrettyPrintWhitespace();
   Expect(Token::LBRACE);
   DeclarationScope* inner_scope = function_scope;
 
@@ -322,6 +323,7 @@ PreParser::Expression PreParser::ParseFunctionLiteral(
     CheckArityRestrictions(formals.arity, kind, formals.has_rest,
                            start_position, formals_end_position);
 
+    AddPrettyPrintWhitespace();
     Expect(Token::LBRACE);
 
     // Parse function body.

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -173,7 +173,7 @@ PreParser::PreParseResult PreParser::PreParseFunction(
   }
 
   if (flags().dump_ast()) {
-    AddASTBreak();
+    AddASTBreak(scanner()->peek_location().beg_pos);
     AddASTEvent(ASTEvent::FunctionBodyEnd, scanner()->peek_location().beg_pos);
   }
 

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -177,7 +177,9 @@ PreParser::PreParseResult PreParser::PreParseFunction(
     AddFunctionEvent(FunctionEvent::BodyEnd, scanner()->peek_location().beg_pos);
   }
 
-  AddPrettyPrintBreak(scanner()->peek_location().beg_pos);
+  if (peek() == Token::RBRACE) {
+    AddPrettyPrintBreak();
+  }
 
   bool allow_duplicate_parameters = false;
   CheckConflictingVarDeclarations(inner_scope);

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -163,9 +163,17 @@ PreParser::PreParseResult PreParser::PreParseFunction(
     inner_scope->set_start_position(position());
   }
 
+  if (flags().dump_ast()) {
+    AddASTEvent(ASTEvent::FunctionBodyStart, position());
+  }
+
   {
     BlockState block_state(&scope_, inner_scope);
     ParseStatementListAndLogFunction(&formals);
+  }
+
+  if (flags().dump_ast()) {
+    AddASTEvent(ASTEvent::FunctionBodyEnd, scanner()->peek_location().beg_pos);
   }
 
   bool allow_duplicate_parameters = false;

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -173,6 +173,7 @@ PreParser::PreParseResult PreParser::PreParseFunction(
   }
 
   if (flags().dump_ast()) {
+    AddASTBreak();
     AddASTEvent(ASTEvent::FunctionBodyEnd, scanner()->peek_location().beg_pos);
   }
 

--- a/deps/v8/src/parsing/preparser.cc
+++ b/deps/v8/src/parsing/preparser.cc
@@ -163,8 +163,8 @@ PreParser::PreParseResult PreParser::PreParseFunction(
     inner_scope->set_start_position(position());
   }
 
-  if (flags().dump_ast()) {
-    AddASTEvent(ASTEvent::FunctionBodyStart, position());
+  if (flags().find_functions()) {
+    AddFunctionEvent(FunctionEvent::BodyStart, position());
   }
 
   {
@@ -172,10 +172,11 @@ PreParser::PreParseResult PreParser::PreParseFunction(
     ParseStatementListAndLogFunction(&formals);
   }
 
-  if (flags().dump_ast()) {
-    AddASTBreak(scanner()->peek_location().beg_pos);
-    AddASTEvent(ASTEvent::FunctionBodyEnd, scanner()->peek_location().beg_pos);
+  if (flags().find_functions()) {
+    AddFunctionEvent(FunctionEvent::BodyEnd, scanner()->peek_location().beg_pos);
   }
+
+  AddPrettyPrintBreak(scanner()->peek_location().beg_pos);
 
   bool allow_duplicate_parameters = false;
   CheckConflictingVarDeclarations(inner_scope);


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5797.  This adds support for pretty printing input source files if configured via the environment, e.g. `PRETTY_PRINT=file.js node -c file.js`.  I'm creating this PR to keep track of this branch but I'm not planning on merging the branch as this adds overhead to the V8 parser which we don't need in other circumstances.